### PR TITLE
Correct BaseVersion() method

### DIFF
--- a/version.go
+++ b/version.go
@@ -316,13 +316,13 @@ func (v Version) BaseVersion() string {
 
 	// Epoch
 	if v.epoch.Compare(part.Zero) == 1 {
-		fmt.Fprintf(&buf, "%d!", v.epoch)
+		fmt.Fprintf(&buf, "%s!", v.epoch.String())
 	}
 
 	// Release segment
-	fmt.Fprintf(&buf, "%d", v.release[0])
+	fmt.Fprintf(&buf, "%s", v.release[0].String())
 	for _, r := range v.release[1:len(v.release)] {
-		fmt.Fprintf(&buf, ".%d", r)
+		fmt.Fprintf(&buf, ".%s", r.String())
 	}
 
 	return buf.String()


### PR DESCRIPTION
With the previous bigint work in #1, I missed some issues in `BaseVersion` where we need to correctly coerce big ints to strings.