### PR TITLE
Allow versions and constraints that contain dash '-' character 

### DIFF
--- a/specifier.go
+++ b/specifier.go
@@ -91,6 +91,7 @@ func newSpecifiers(v string, santizer func(string) string, opts ...SpecifierOpti
 		if strings.TrimSpace(vv) == "*" {
 			vv = ">=0.0.0"
 		}
+		vv = strings.ReplaceAll(vv, "-", ".")
 
 		// Validate the segment
 		if !validConstraintRegexp.MatchString(vv) {

--- a/specifier.go
+++ b/specifier.go
@@ -67,16 +67,15 @@ type specifier struct {
 }
 
 // NewSpecifiersWithSanitizer parses a given specifier and returns a new instance of Specifiers
-// it santiizes the version string before parsing it with the given function.
+// it sanitizes the version string before parsing it with the given function.
 func NewSpecifiersWithSanitizer(v string, sanitizer func(string) string, opts ...SpecifierOption) (Specifiers, error) {
 	return newSpecifiers(v, sanitizer, opts...)
 }
 
-// NewPermisiveSpecifiers parses a given specifier and returns a new instance of Specifiers. It is
-// similar to NewSpecifiersWithSanitizer but allows dash '-' characters in a version and replaces them
-// with periods.
-func NewPermisiveSpecifiers(v string, sanitizer func(string) string, opts ...SpecifierOption) (Specifiers, error) {
-	return newPermisiveSpecifiers(v, func(s string) string { return s }, opts...)
+// NewRSpecifiers parses a given specifier and returns a new instance of Specifiers intended for
+// working with R package versions.
+func NewRSpecifiers(v string, sanitizer func(string) string, opts ...SpecifierOption) (Specifiers, error) {
+	return newRSpecifiers(v, func(s string) string { return s }, opts...)
 }
 
 // NewSpecifiers parses a given specifier and returns a new instance of Specifiers
@@ -85,7 +84,7 @@ func NewSpecifiers(v string, opts ...SpecifierOption) (Specifiers, error) {
 }
 
 // NewSpecifiers parses a given specifier and returns a new instance of Specifiers
-func newPermisiveSpecifiers(v string, santizer func(string) string, opts ...SpecifierOption) (Specifiers, error) {
+func newRSpecifiers(v string, sanitizer func(string) string, opts ...SpecifierOption) (Specifiers, error) {
 	c := new(conf)
 
 	// Apply options
@@ -112,7 +111,7 @@ func newPermisiveSpecifiers(v string, santizer func(string) string, opts ...Spec
 
 		var specs []specifier
 		for _, single := range ss {
-			s, err := newSpecifier(single, santizer)
+			s, err := newSpecifier(single, sanitizer)
 			if err != nil {
 				return Specifiers{}, err
 			}
@@ -129,7 +128,7 @@ func newPermisiveSpecifiers(v string, santizer func(string) string, opts ...Spec
 }
 
 // NewSpecifiers parses a given specifier and returns a new instance of Specifiers
-func newSpecifiers(v string, santizer func(string) string, opts ...SpecifierOption) (Specifiers, error) {
+func newSpecifiers(v string, sanitizer func(string) string, opts ...SpecifierOption) (Specifiers, error) {
 	c := new(conf)
 
 	// Apply options
@@ -155,7 +154,7 @@ func newSpecifiers(v string, santizer func(string) string, opts ...SpecifierOpti
 
 		var specs []specifier
 		for _, single := range ss {
-			s, err := newSpecifier(single, santizer)
+			s, err := newSpecifier(single, sanitizer)
 			if err != nil {
 				return Specifiers{}, err
 			}

--- a/specifier_test.go
+++ b/specifier_test.go
@@ -69,6 +69,12 @@ func TestNewConstraints(t *testing.T) {
 		// Cannot use a prefix matching after a .devN version
 		{"==1.0.dev1.*", true},
 		{"!=1.0.dev1.*", true},
+
+		// Replace dashes '-' with dots to form new version segment
+		{"== 3.99-0.14", false},
+		{"==3.99-0.14", false},
+		{"== 3.99.0.14", false},
+		{"==3.99.0.14", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.constraint, func(t *testing.T) {

--- a/specifier_test.go
+++ b/specifier_test.go
@@ -88,7 +88,7 @@ func TestNewConstraints(t *testing.T) {
 	}
 }
 
-func TestNewPermisiveSpecifiers(t *testing.T) {
+func TestNewRSpecifiers(t *testing.T) {
 	tests := []struct {
 		constraint string
 		wantErr    bool

--- a/specifier_test.go
+++ b/specifier_test.go
@@ -158,7 +158,7 @@ func TestNewPermisiveSpecifiers(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.constraint, func(t *testing.T) {
-			_, err := NewPermisiveSpecifiers(tt.constraint, func(s string) string { return s })
+			_, err := NewRSpecifiers(tt.constraint, func(s string) string { return s })
 			if tt.wantErr {
 				assert.NotNil(t, err)
 			} else {


### PR DESCRIPTION
## About

This PR updates `go-pep440-version` to support specifiers that have a version containing a dash `-` character by replacing it with a dot `.` character and forming a new segment in the version. For example, `== 3.99-0.14` will now be converted to `== 3.99.0.14` by `newSpecifiers()` instead of raising an error. These changes are related to an [issue with curated CRAN requirements containing a dash](https://github.com/rstudio/package-manager/issues/14475). Once a new version of `go-pep440-version` is released for this change, the [PR](https://github.com/rstudio/package-manager/pull/14505) opened to fix the CRAN requirements issue will be updated to use this new version.

## Testing

Several new test cases were added to verify that an error is not raised when encountering a version containing a dash character.

## Feedback / Questions

Should we update `go-pep440-version` to perform this substitution implicitly or should we expand the API to allow callers to explicitly have this substitution performed? We are using this package for both R / CRAN  and Python requirements parsing / comparison, with the former allowing for much looser semantic version formats, which is what has prompted this change. Is there a risk that we might introduce an issue down the road when handling Python versions? 