### PR TITLE
Order pre-release spellings longest-first

### DIFF
--- a/prerelease_spelling_test.go
+++ b/prerelease_spelling_test.go
@@ -1,0 +1,91 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// PEP 440 permits "alpha", "beta", "pre", "preview" and "c" as alternate
+// spellings of "a", "b", "rc" and "rc". A specifier string must never yield
+// more specifiers than it has operators.
+//
+// specifierRegexp is UNANCHORED, so nothing forces the pre_l alternation to
+// consume the whole token: with a shortest-first ordering, Go's leftmost-first
+// matching accepted "a" for "alpha", leaving "lpha1", and FindAllString then
+// harvested the trailing "1" as a SECOND, operator-less specifier. Both were
+// ANDed together, so "==1.0alpha1" parsed without error and then matched
+// nothing at all -- a silent wrong answer:
+//
+//	"==1.0alpha1"   -> "==1.0a,1"
+//	"==1.0-beta2"   -> "==1.0-b,2"
+//	"==1.0preview1" -> "==1.0pre,1"
+//
+// versionRegex is anchored, so Parse alone was unaffected; only the specifier
+// path corrupted. pypa/packaging orders its equivalent alternation
+// longest-before-prefix for this same reason (Python's re is also
+// leftmost-first).
+//
+// See rstudio/package-manager#19369.
+func TestNewSpecifiers_LongPreReleaseSpellingIsOneSpecifier(t *testing.T) {
+	tests := []struct {
+		specifier string
+		matches   string
+	}{
+		{"==1.0alpha1", "1.0a1"},
+		{"==1.0-beta2", "1.0b2"},
+		{"==1.0preview1", "1.0rc1"},
+		{"==1.0pre1", "1.0rc1"},
+		{"==1.0c1", "1.0rc1"},
+		// post_l is `post|rev|r`. "r" IS a prefix of "rev", but it is listed
+		// last, so leftmost-first already picks the long form. Guard cases
+		// against a future reorder.
+		{"==1.0rev1", "1.0.post1"},
+		{"==1.0post1", "1.0.post1"},
+		{"==1.0r1", "1.0.post1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.specifier, func(t *testing.T) {
+			specs, err := NewSpecifiers(tt.specifier)
+			require.NoError(t, err)
+
+			count := 0
+			for _, group := range specs.specifiers {
+				count += len(group)
+			}
+			assert.Equal(t, 1, count, "expected exactly one specifier, got %q", specs.String())
+
+			v, err := Parse(tt.matches)
+			require.NoError(t, err)
+			assert.True(t, specs.Check(v), "%q should match %q", tt.specifier, tt.matches)
+		})
+	}
+}
+
+// The long pre-release spellings normalize to their canonical short forms.
+// These pass before and after the reorder (versionRegex is anchored); they pin
+// the alias mapping and document that Parse was never the broken path.
+func TestParse_LongPreReleaseSpellings(t *testing.T) {
+	tests := []struct {
+		version string
+		want    string
+	}{
+		{"1.0alpha1", "1.0a1"},
+		{"1.0.alpha1", "1.0a1"},
+		{"1.0-alpha1", "1.0a1"},
+		{"1.0ALPHA1", "1.0a1"},
+		{"1.0beta2", "1.0b2"},
+		{"1.0preview1", "1.0rc1"},
+		{"1.0pre1", "1.0rc1"},
+		{"1.0c1", "1.0rc1"},
+		{"1.0rc1", "1.0rc1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			v, err := Parse(tt.version)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, v.String())
+		})
+	}
+}

--- a/version.go
+++ b/version.go
@@ -39,7 +39,12 @@ const (
 		`(?:` +
 		`(?:(?P<epoch>[0-9]+)!)?` + // epoch
 		`(?P<release>[0-9]+(?:\.[0-9]+)*)` + // release segment
-		`(?P<pre>[-_\.]?(?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))[-_\.]?(?P<pre_n>[0-9]+)?)?` + // pre-release
+		// The pre-release spellings MUST be ordered so that no alternative is
+		// preceded by one of its own prefixes: Go's regexp is leftmost-first,
+		// so listing "a" before "alpha" makes "alpha" match as just "a",
+		// truncating the version mid-token. pypa/packaging orders its
+		// equivalent alternation the same way, for the same reason.
+		`(?P<pre>[-_\.]?(?P<pre_l>(alpha|a|beta|b|preview|pre|c|rc))[-_\.]?(?P<pre_n>[0-9]+)?)?` + // pre-release
 		`(?P<post>(?:-(?P<post_n1>[0-9]+))|(?:[-_\.]?(?P<post_l>post|rev|r)[-_\.]?(?P<post_n2>[0-9]+)?))?` + // post release
 		`(?P<dev>[-_\.]?(?P<dev_l>dev)[-_\.]?(?P<dev_n>[0-9]+)?)?)` + // dev release
 		`(?:\+(?P<local>[a-z0-9]+(?:[-_\.][a-z0-9]+)*))?` // local version`


### PR DESCRIPTION
## What

Order the PEP 440 pre-release spellings longest-first in the version regex.

## Why

PEP 440 permits `alpha`, `beta`, `pre`, `preview` and `c` as alternate spellings of `a`, `b`, `rc` and `rc`. The `pre_l` alternation listed them shortest-first:

```go
(?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))
```

**Go's `regexp` is leftmost-first, not leftmost-longest**, so `alpha` matched as just `a`.

`versionRegex` is anchored (`^\s*...\s*$`), so backtracking forced a correct full-token match and `Parse` was unaffected. But `specifierRegexp` is **unanchored**, so it kept the short match and `FindAllString` then harvested the trailing digits as a **second, operator-less specifier**:

| input | parsed as |
|---|---|
| `==1.0alpha1` | `==1.0a` **and** `1` |
| `==1.0-beta2` | `==1.0-b` **and** `2` |
| `==1.0preview1` | `==1.0pre` **and** `1` |

Both halves were ANDed together, so the constraint **parsed without error and then matched nothing at all** — a silent wrong answer rather than a rejection.

Verified against `pypa/packaging` 26.2, which accepts `==1.0alpha1` and matches `1.0a1`. Notably, pypa orders its own equivalent alternation `alpha|a|beta|b|preview|pre|c|rc` — longest-before-prefix — for exactly this reason, since Python's `re` is also leftmost-first. This restores that ordering.

## Scope

`post_l` (`post|rev|r`) was checked and is **already safe**: `r` is a prefix of `rev`, but it is listed last, so leftmost-first already picks the long form. Verified against the unfixed baseline; guard cases added so a future reorder can't silently regress it.

## Testing

- `TestNewSpecifiers_LongPreReleaseSpellingIsOneSpecifier` — asserts a specifier string never yields more specifiers than it has operators, and that each long spelling matches its canonical version. **Verified to fail without the one-line fix.**
- `TestParse_LongPreReleaseSpellings` — pins the alias mapping. Passes before and after (the anchored regex was never broken); kept as a characterization test and labeled as such, so nobody mistakes it for the regression test.
- `go test ./...` green; `gofmt` clean.

## Downstream

Fixes the library side of rstudio/package-manager#19369, where the defect is reachable today through PPM's `util.PythonCheckSpecifier`. **This PR needs a `v0.1.1` tag after merge** so PPM can bump off `v0.1.0`.

Note: the same defect existed in `posit-dev/go-python-packaging` (the successor module) and is fixed there in a companion PR.
